### PR TITLE
docs: add CHANGELOG.md (Keep a Changelog + SemVer 2.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Initial scaffold — reference AWS ParallelCluster configurations and OOD setup scripts for aws-openondemand.
+- Cluster configs: `basic`, `burst`, `gpu`, and `hybrid` (`configs/*/cluster-config.yaml`).
+- OOD cluster definition template (`ood-clusters/parallelcluster.yml.tmpl`).
+- Setup scripts: `gen-cluster-yaml.sh`, `setup-head-node.sh`, and `setup-compute-nodes.sh`.
+- CI workflow and Dependabot configuration.


### PR DESCRIPTION
Adds `CHANGELOG.md` adopting the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) + [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html) convention used across the rest of the project ecosystem (`oidc-pam`, `aws-hubzero`, `substrate`, `aws-openondemand`).

This repo is pre-release (no tags yet), so all current work is recorded under `## [Unreleased]`. The entries are derived from the existing commit history and README — no code changes.